### PR TITLE
chore(workflows): Add cache to run-tests

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -17,9 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
       - name: npm install, build, and test
         run: |
           npm ci


### PR DESCRIPTION
This pull-request adds caching recently added to `@actions/setup-node`.

See: https://github.com/actions/setup-node#caching-packages-dependencies